### PR TITLE
Add local-part of mail address to request URL parameter

### DIFF
--- a/src/wkd.js
+++ b/src/wkd.js
@@ -51,9 +51,10 @@ class WKD {
     const localPartEncoded = new TextEncoder().encode(localPart.toLowerCase());
     const localPartHashed = new Uint8Array(await this._subtle.digest('SHA-1', localPartEncoded));
     const localPartBase32 = encodeZBase32(localPartHashed);
+    const localPartEscaped = encodeURIComponent(localPart);
 
-    const urlAdvanced = `https://openpgpkey.${domain}/.well-known/openpgpkey/${domain}/hu/${localPartBase32}`;
-    const urlDirect = `https://${domain}/.well-known/openpgpkey/hu/${localPartBase32}`;
+    const urlAdvanced = `https://openpgpkey.${domain}/.well-known/openpgpkey/${domain}/hu/${localPartBase32}?l=${localPartEscaped}`;
+    const urlDirect = `https://${domain}/.well-known/openpgpkey/hu/${localPartBase32}?l=${localPartEscaped}`;
 
     let response;
     try {


### PR DESCRIPTION
### IETF OpenPGP Web Key Directory Draft

According to https://datatracker.ietf.org/doc/html/draft-koch-openpgp-webkey-service-13.html#section-3.1:

> * the unchanged local-part as a parameter with name "l" using proper percent escaping.
>
> An example for such an advanced method URI to lookup the key for Joe.Doe@Example.ORG is:
> https://openpgpkey.example.org/.well-known/openpgpkey/example.org/hu/iy9q119eutrkn8s1mk4r39qejnbu3n5q?l=Joe.Doe

This PR adds the local part, eg. `l=Joe.Doe`. This is non-optional, according to the spec.

### ProtonMail's WKS Implementation

Ironically, protonmail requires the parameter. Leaving off the local-part for the [wkd url ](https://openpgpkey.protonmail.com/.well-known/openpgpkey/protonmail.com/hu/4wo84t99bdeb6q9369en4wuy4qizys3o)of `stewSquared@protonmail.com` results in a 400 error:

> Specify the unchanged local-part as a parameter with name "l" using proper percent escaping

### GnuPG's gpg-wks-client and percent encoding

It's worth noting that `gpg-wks-client --print-wkd-url` doesn't escape the local part in the parameter. I don't know if this has compatibility ramifications for `gpg --locate-keys`