### PR TITLE
Fix typescript declaration

### DIFF
--- a/src/wkd.d.ts
+++ b/src/wkd.d.ts
@@ -1,4 +1,4 @@
-export class WKD {
+export default class WKD {
   constructor();
-  public async lookup(options: { email: string }): Uint8Array;
+  public lookup(options: { email: string }): Promise<Uint8Array>;
 }


### PR DESCRIPTION
The typescript export declaration is currently wrong:

1. in the `wkd.js` source, the class literal `WKD` is being exported. The equivalent in typescript is `export default class WKD`.
2. The `async` keyword is not allowed in declaration files. Instead, `async` methods are indicated by their `Promise` return type.

Currently, in order to use this library with Typescript, a few workarounds are needed:

1. Create a constant that is equal to the "real" `WKD` class, but with the type of the `WKD` class as declared in the typescript declaration file
    ```javascript
    import WKD from '@openpgp/wkd-client';
    const WKDClass = (WKD as unknown) as typeof WKD.WKD;
    const wkd = new WKDClass();
    await wkd.lookup({ email });
    ```
2. Add the skipLibCheck parameter to tsc, either as [option in `tsconfig.json`](https://www.typescriptlang.org/tsconfig#skipLibCheck) or as command line parameter.